### PR TITLE
Remove deprecated `m_canonical_dedup_map`

### DIFF
--- a/src/core/atom_store.h
+++ b/src/core/atom_store.h
@@ -329,10 +329,6 @@ private:
     // Used for all atom types to enable efficient lookup
     std::unordered_map<types::AtomId, size_t, AtomIdHash> m_content_index;
 
-    // Deduplication map: hash -> index in m_atoms
-    // Only used for Canonical atoms (DEPRECATED - merged with m_content_index)
-    // TODO: Remove m_canonical_dedup_map after verifying m_content_index works
-    std::unordered_map<types::AtomId, size_t, AtomIdHash> m_canonical_dedup_map;
 
     // ===== REFERENCE LAYER (Entity-Atom Associations) =====
 


### PR DESCRIPTION
## Summary

Removed the deprecated m_canonical_dedup_map declaration and its TODO comment

## Related Issues


Related to #7 Deprecated Code Removal 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor (no behavioral change)
- [ ] Build / tooling
- [ ] Documentation
- [ ] Other (please describe)

## Breaking Changes

- [X] No breaking changes
- [ ] Yes — breaking changes (describe migration path below)


## Architecture Impact

Does this change affect architectural changes?

- [X] No
- [ ] Yes — ADR included
- [ ] Yes — ADR required but not included yet


## Documentation

- [X] No documentation changes required
- [ ] Documentation updated (list files below)
- [ ] Documentation-only change


## Testing

How was this change validated?

- [X] Existing tests pass
- [ ] New tests added
- [ ] Manual verification
- [ ] Not applicable (documentation/config only)

## AI-Assisted Contribution

- [X] No AI assistance used
- [ ] Yes — AI assisted (complete checklist below)

## Notes for Reviewers
